### PR TITLE
Upgrade deps

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -3,4 +3,4 @@
 var P = require('promise')
 var standard = require('standard')
 
-exports.lintFiles = P.denodeify(standard.lintFiles)
+exports.lintFiles = P.denodeify(standard.lintFiles.bind(standard))

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -20,19 +20,19 @@ exports.reporter = function reporter (grunt, data) {
     total += file.messages.length
     output += chalk.underline.bold(filePath) + '\n'
     output += table(file.messages.map(function (message) {
-        return [
-          '',
-          chalk.gray('line ' + message.line || 0),
-          chalk.gray('col ' + message.column || 0),
-          chalk.blue(message.message),
-          isVerbose ? chalk.gray(message.ruleId) : ''
-        ]
-      }, {
-        align: ['', 'r', 'l'],
-        stringLength: function (str) {
-          return chalk.stripColor(str).length
-        }
-      })) + '\n\n'
+      return [
+        '',
+        chalk.gray('line ' + message.line || 0),
+        chalk.gray('col ' + message.column || 0),
+        chalk.blue(message.message),
+        isVerbose ? chalk.gray(message.ruleId) : ''
+      ]
+    }, {
+      align: ['', 'r', 'l'],
+      stringLength: function (str) {
+        return chalk.stripColor(str).length
+      }
+    })) + '\n\n'
   })
 
   var str = util.format('✖ %d %s\n', total, grunt.util.pluralize(total, 'problem/problems'))

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,48 +1,44 @@
 {
   "name": "grunt-standard",
-  "version": "1.0.1",
-  "npm-shrinkwrap-version": "5.3.0",
-  "node-version": "v0.10.35",
+  "version": "1.0.2",
+  "npm-shrinkwrap-version": "5.4.0",
+  "node-version": "v0.10.40",
   "dependencies": {
     "chalk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
       "dependencies": {
         "ansi-styles": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "has-ansi": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-            },
-            "get-stdin": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             }
           }
         },
         "strip-ansi": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             }
           }
         },
         "supports-color": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
@@ -91,20 +87,20 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.1",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz"
+                      "version": "2.7.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "lodash": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
@@ -121,18 +117,22 @@
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
             }
           }
         },
         "grunt-legacy-log": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
+            },
             "lodash": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
@@ -185,12 +185,12 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz"
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
             },
             "sigmund": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
@@ -199,8 +199,8 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
@@ -250,21 +250,193 @@
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
+        "grunt": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.22",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+            },
+            "coffee-script": {
+              "version": "1.3.3",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.2-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+            },
+            "eventemitter2": {
+              "version": "0.4.14",
+              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+            },
+            "exit": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            },
+            "findup-sync": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                }
+              }
+            },
+            "getobject": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+            },
+            "glob": {
+              "version": "3.1.21",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                },
+                "inherits": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                }
+              }
+            },
+            "grunt-legacy-log": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
+              "dependencies": {
+                "grunt-legacy-log-utils": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
+                },
+                "lodash": {
+                  "version": "2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "grunt-legacy-util": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+            },
+            "hooker": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+            },
+            "iconv-lite": {
+              "version": "0.2.11",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+            },
+            "js-yaml": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "0.1.16",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+                  "dependencies": {
+                    "underscore": {
+                      "version": "1.7.0",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            },
+            "lodash": {
+              "version": "0.9.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "underscore.string": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+            },
+            "which": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            }
+          }
+        },
         "request": {
-          "version": "2.55.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "version": "2.64.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.5.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "bl": {
-              "version": "0.9.4",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.0.33",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
@@ -278,53 +450,103 @@
                       "version": "0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                    },
                     "string_decoder": {
                       "version": "0.10.31",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
               }
             },
             "caseless": {
-              "version": "0.9.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
-              "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "version": "1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.9.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                  "version": "1.4.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                 }
               }
             },
             "har-validator": {
-              "version": "1.6.1",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.6.1.tgz",
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
-                  "version": "2.9.24",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
+                  "version": "2.10.2",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                },
+                "chalk": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
                 },
                 "commander": {
-                  "version": "2.8.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.0.tgz",
+                  "version": "2.8.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
@@ -333,16 +555,16 @@
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.1.tgz",
+                  "version": "2.12.2",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
@@ -351,8 +573,8 @@
                       }
                     },
                     "jsonpointer": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
@@ -363,20 +585,20 @@
               }
             },
             "hawk": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "dependencies": {
                 "boom": {
-                  "version": "2.7.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                  "version": "2.9.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
                 },
                 "cryptiles": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "hoek": {
-                  "version": "2.12.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
@@ -385,8 +607,8 @@
               }
             },
             "http-signature": {
-              "version": "0.10.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.1.11",
@@ -407,16 +629,16 @@
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "version": "2.1.7",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.19.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
                 }
               }
             },
@@ -425,38 +647,36 @@
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "oauth-sign": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "qs": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "tough-cookie": {
-              "version": "0.12.1",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                }
-              }
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
             },
             "tunnel-agent": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             }
           }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "npm-shrinkwrap": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-shrinkwrap/-/npm-shrinkwrap-5.3.0.tgz",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/npm-shrinkwrap/-/npm-shrinkwrap-5.4.0.tgz",
       "dependencies": {
         "array-find": {
           "version": "0.1.1",
@@ -505,16 +725,16 @@
               "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
               "dependencies": {
                 "wordwrap": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
                 }
               }
             }
           }
         },
         "minimist": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "msee": {
           "version": "0.1.1",
@@ -559,16 +779,16 @@
               }
             },
             "marked": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.3.tgz"
+              "version": "0.3.5",
+              "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
             },
             "nopt": {
               "version": "2.1.2",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
@@ -1001,12 +1221,12 @@
           "resolved": "https://registry.npmjs.org/read-json/-/read-json-0.1.0.tgz"
         },
         "rimraf": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
           "dependencies": {
             "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
@@ -1023,12 +1243,12 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
@@ -1043,250 +1263,2270 @@
                   }
                 },
                 "once": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             }
           }
         },
         "run-parallel": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.0.tgz",
-          "dependencies": {
-            "dezalgo": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.1.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
-                },
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.4.tgz"
         },
         "run-series": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.0.tgz",
-          "dependencies": {
-            "dezalgo": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.1.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
-                },
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz"
         },
         "safe-json-parse": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-2.0.0.tgz"
         },
         "semver": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "sorted-object": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz"
         },
         "string-template": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.0.tgz",
-          "dependencies": {
-            "js-string-escape": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz"
-            }
-          }
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
         }
       }
     },
     "promise": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.0.0.tgz",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.0.4.tgz",
       "dependencies": {
         "asap": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.2.tgz"
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
         }
       }
     },
     "standard": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-3.7.0.tgz",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-5.3.1.tgz",
       "dependencies": {
-        "dezalgo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.1.tgz",
+        "eslint-config-standard": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-4.4.0.tgz"
+        },
+        "eslint-config-standard-react": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard-react/-/eslint-config-standard-react-1.1.0.tgz"
+        },
+        "eslint-plugin-react": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.4.2.tgz"
+        },
+        "eslint-plugin-standard": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-1.3.1.tgz"
+        },
+        "standard-engine": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-2.2.0.tgz",
           "dependencies": {
-            "asap": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+            "defaults": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                }
+              }
             },
-            "wrappy": {
+            "deglob": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.0.1.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "ignore": {
+                  "version": "2.2.18",
+                  "resolved": "https://registry.npmjs.org/ignore/-/ignore-2.2.18.tgz"
+                },
+                "path": {
+                  "version": "0.11.14",
+                  "resolved": "https://registry.npmjs.org/path/-/path-0.11.14.tgz"
+                },
+                "run-parallel": {
+                  "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.4.tgz"
+                },
+                "uniq": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                }
+              }
+            },
+            "dezalgo": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                },
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "eslint": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.6.0.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "concat-stream": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.2",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "doctrine": {
+                  "version": "0.7.0",
+                  "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "1.1.6",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "escope": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+                  "dependencies": {
+                    "es6-map": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.8",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                            },
+                            "es6-symbol": {
+                              "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
+                            }
+                          }
+                        },
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "dependencies": {
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "es6-set": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                            },
+                            "es6-symbol": {
+                              "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
+                            }
+                          }
+                        },
+                        "es6-symbol": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                        },
+                        "event-emitter": {
+                          "version": "0.3.4",
+                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+                        }
+                      }
+                    },
+                    "es6-weak-map": {
+                      "version": "0.1.4",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.8",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                            },
+                            "es6-symbol": {
+                              "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
+                            }
+                          }
+                        },
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "esrecurse": {
+                      "version": "3.1.1",
+                      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
+                    },
+                    "estraverse": {
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                    }
+                  }
+                },
+                "espree": {
+                  "version": "2.2.5",
+                  "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+                },
+                "estraverse": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
+                },
+                "estraverse-fb": {
+                  "version": "1.3.1",
+                  "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "file-entry-cache": {
+                  "version": "1.2.4",
+                  "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+                  "dependencies": {
+                    "flat-cache": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.9.tgz",
+                      "dependencies": {
+                        "del": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/del/-/del-2.0.2.tgz",
+                          "dependencies": {
+                            "globby": {
+                              "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
+                              "dependencies": {
+                                "array-union": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                                  "dependencies": {
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "arrify": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "is-path-cwd": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                            },
+                            "is-path-in-cwd": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                              "dependencies": {
+                                "is-path-inside": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "rimraf": {
+                              "version": "2.4.3",
+                              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                        },
+                        "read-json-sync": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "3.0.8",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                            }
+                          }
+                        },
+                        "write": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "8.11.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz"
+                },
+                "handlebars": {
+                  "version": "4.0.3",
+                  "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.3.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.4.2",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                    },
+                    "optimist": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.10",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.4.4",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "uglify-js": {
+                      "version": "2.4.24",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.2.10",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.1.34",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "uglify-to-browserify": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                        },
+                        "yargs": {
+                          "version": "3.5.4",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "decamelize": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                            },
+                            "window-size": {
+                              "version": "0.1.0",
+                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "inquirer": {
+                  "version": "0.9.0",
+                  "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    },
+                    "cli-width": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+                    },
+                    "figures": {
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "readline2": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                      "dependencies": {
+                        "mute-stream": {
+                          "version": "0.0.4",
+                          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                        },
+                        "strip-ansi": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "run-async": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.2",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rx-lite": {
+                      "version": "2.5.2",
+                      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.12.2",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    }
+                  }
+                },
+                "is-resolvable": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+                  "dependencies": {
+                    "tryit": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.1.tgz"
+                    }
+                  }
+                },
+                "js-yaml": {
+                  "version": "3.4.2",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.2.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                    }
+                  }
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz",
+                  "dependencies": {
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.clonedeep": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+                  "dependencies": {
+                    "lodash._baseclone": {
+                      "version": "3.3.0",
+                      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+                      "dependencies": {
+                        "lodash._arraycopy": {
+                          "version": "3.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                        },
+                        "lodash._arrayeach": {
+                          "version": "3.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                        },
+                        "lodash._baseassign": {
+                          "version": "3.2.0",
+                          "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                          "dependencies": {
+                            "lodash._basecopy": {
+                              "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._basefor": {
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        },
+                        "lodash.keys": {
+                          "version": "3.1.2",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                          "dependencies": {
+                            "lodash._getnative": {
+                              "version": "3.9.1",
+                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                            },
+                            "lodash.isarguments": {
+                              "version": "3.0.4",
+                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash.merge": {
+                  "version": "3.3.2",
+                  "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+                  "dependencies": {
+                    "lodash._arraycopy": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                    },
+                    "lodash._arrayeach": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                    },
+                    "lodash._createassigner": {
+                      "version": "3.1.1",
+                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._bindcallback": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.1",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    },
+                    "lodash.isplainobject": {
+                      "version": "3.2.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basefor": {
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "lodash.istypedarray": {
+                      "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                    },
+                    "lodash.keysin": {
+                      "version": "3.0.8",
+                      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+                    },
+                    "lodash.toplainobject": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.omit": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+                  "dependencies": {
+                    "lodash._arraymap": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
+                    },
+                    "lodash._basedifference": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+                      "dependencies": {
+                        "lodash._baseindexof": {
+                          "version": "3.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+                        },
+                        "lodash._cacheindexof": {
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+                        },
+                        "lodash._createcache": {
+                          "version": "3.1.2",
+                          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                          "dependencies": {
+                            "lodash._getnative": {
+                              "version": "3.9.1",
+                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._baseflatten": {
+                      "version": "3.1.4",
+                      "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                      "dependencies": {
+                        "lodash.isarguments": {
+                          "version": "3.0.4",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    },
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._pickbyarray": {
+                      "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+                    },
+                    "lodash._pickbycallback": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+                      "dependencies": {
+                        "lodash._basefor": {
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "lodash.keysin": {
+                      "version": "3.0.8",
+                      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                      "dependencies": {
+                        "lodash.isarguments": {
+                          "version": "3.0.4",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                },
+                "optionator": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                  "dependencies": {
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                    },
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "path-is-inside": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+                },
+                "shelljs": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                },
+                "text-table": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+                },
+                "to-double-quotes": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                    }
+                  }
+                },
+                "to-single-quotes": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                    }
+                  }
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                },
+                "xml-escape": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+                }
+              }
+            },
+            "find-root": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.1.tgz"
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "multiline": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/multiline/-/multiline-1.0.2.tgz",
+              "dependencies": {
+                "strip-indent": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                }
+              }
+            },
+            "pkg-config": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.0.tgz",
+              "dependencies": {
+                "debug-log": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.0.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
-        "eslint": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.18.0.tgz",
+        "standard-format": {
+          "version": "1.6.8",
+          "resolved": "https://registry.npmjs.org/standard-format/-/standard-format-1.6.8.tgz",
           "dependencies": {
-            "concat-stream": {
-              "version": "1.4.8",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+            "deglob": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.0.1.tgz",
               "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                "dezalgo": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
                   "dependencies": {
-                    "core-util-is": {
+                    "asap": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                    },
+                    "wrappy": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "find-root": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.1.tgz"
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "ignore": {
+                  "version": "2.2.18",
+                  "resolved": "https://registry.npmjs.org/ignore/-/ignore-2.2.18.tgz"
+                },
+                "path": {
+                  "version": "0.11.14",
+                  "resolved": "https://registry.npmjs.org/path/-/path-0.11.14.tgz"
+                },
+                "pkg-config": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.0.tgz",
+                  "dependencies": {
+                    "debug-log": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.0.tgz"
+                    }
+                  }
+                },
+                "run-parallel": {
+                  "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.4.tgz"
+                },
+                "uniq": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "esformatter": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.7.3.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "disparity": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "diff": {
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+                    }
+                  }
+                },
+                "espree": {
+                  "version": "1.12.3",
+                  "resolved": "https://registry.npmjs.org/espree/-/espree-1.12.3.tgz"
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "mout": {
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
+                },
+                "npm-run": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-1.1.1.tgz",
+                  "dependencies": {
+                    "npm-path": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.0.2.tgz",
+                      "dependencies": {
+                        "which": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                          "dependencies": {
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "serializerr": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.1.tgz",
+                      "dependencies": {
+                        "protochain": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "sync-exec": {
+                      "version": "0.5.0",
+                      "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.5.0.tgz"
+                    }
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+                },
+                "rocambole": {
+                  "version": "0.7.0",
+                  "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.6.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                    }
+                  }
+                },
+                "rocambole-indent": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rocambole-linebreak": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.1.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "4.3.6",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                    }
+                  }
+                },
+                "rocambole-node": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-node/-/rocambole-node-1.0.0.tgz"
+                },
+                "rocambole-token": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
+                },
+                "rocambole-whitespace": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "repeat-string": {
+                      "version": "1.5.2",
+                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "2.2.1",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                },
+                "supports-color": {
+                  "version": "1.3.1",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                },
+                "user-home": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "esformatter-eol-last": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/esformatter-eol-last/-/esformatter-eol-last-1.0.0.tgz",
+              "dependencies": {
+                "string.prototype.endswith": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz"
+                }
+              }
+            },
+            "esformatter-jsx": {
+              "version": "2.3.5",
+              "resolved": "https://registry.npmjs.org/esformatter-jsx/-/esformatter-jsx-2.3.5.tgz",
+              "dependencies": {
+                "babel-core": {
+                  "version": "5.8.25",
+                  "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.25.tgz",
+                  "dependencies": {
+                    "babel-plugin-constant-folding": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                    },
+                    "babel-plugin-dead-code-elimination": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                    },
+                    "babel-plugin-eval": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                    },
+                    "babel-plugin-inline-environment-variables": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                    },
+                    "babel-plugin-jscript": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                    },
+                    "babel-plugin-member-expression-literals": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                    },
+                    "babel-plugin-property-literals": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                    },
+                    "babel-plugin-proto-to-assign": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                    },
+                    "babel-plugin-react-constant-elements": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                    },
+                    "babel-plugin-react-display-name": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                    },
+                    "babel-plugin-remove-console": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                    },
+                    "babel-plugin-remove-debugger": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                    },
+                    "babel-plugin-runtime": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                    },
+                    "babel-plugin-undeclared-variables-check": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                      "dependencies": {
+                        "leven": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-plugin-undefined-to-void": {
+                      "version": "1.1.6",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                    },
+                    "babylon": {
+                      "version": "5.8.23",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.23.tgz"
+                    },
+                    "bluebird": {
+                      "version": "2.10.2",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.1.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "convert-source-map": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                    },
+                    "core-js": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.1.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "detect-indent": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                      "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "fs-readdir-recursive": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                    },
+                    "globals": {
+                      "version": "6.4.1",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                    },
+                    "home-or-tmp": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                      "dependencies": {
+                        "os-tmpdir": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                        },
+                        "user-home": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "is-integer": {
+                      "version": "1.0.6",
+                      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "js-tokens": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                    },
+                    "json5": {
+                      "version": "0.4.0",
+                      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                    },
+                    "line-numbers": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                      "dependencies": {
+                        "left-pad": {
+                          "version": "0.0.3",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "output-file-sync": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                      "dependencies": {
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    },
+                    "path-exists": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    },
+                    "private": {
+                      "version": "0.1.6",
+                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                    },
+                    "regenerator": {
+                      "version": "0.8.35",
+                      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.35.tgz",
+                      "dependencies": {
+                        "commoner": {
+                          "version": "0.10.3",
+                          "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
+                          "dependencies": {
+                            "commander": {
+                              "version": "2.5.1",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+                            },
+                            "glob": {
+                              "version": "4.2.2",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.7.0",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.2",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "3.0.8",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                            },
+                            "iconv-lite": {
+                              "version": "0.4.13",
+                              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                            },
+                            "install": {
+                              "version": "0.1.8",
+                              "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.5.1",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                              "dependencies": {
+                                "minimist": {
+                                  "version": "0.0.8",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                }
+                              }
+                            },
+                            "q": {
+                              "version": "1.1.2",
+                              "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "defs": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
+                          "dependencies": {
+                            "alter": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                              "dependencies": {
+                                "stable": {
+                                  "version": "0.1.5",
+                                  "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                                }
+                              }
+                            },
+                            "ast-traverse": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                            },
+                            "breakable": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                            },
+                            "esprima-fb": {
+                              "version": "8001.1001.0-dev-harmony-fb",
+                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                            },
+                            "simple-fmt": {
+                              "version": "0.1.0",
+                              "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                            },
+                            "simple-is": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                            },
+                            "stringmap": {
+                              "version": "0.2.2",
+                              "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                            },
+                            "stringset": {
+                              "version": "0.2.1",
+                              "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                            },
+                            "tryor": {
+                              "version": "0.1.2",
+                              "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                            },
+                            "yargs": {
+                              "version": "1.3.3",
+                              "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+                            }
+                          }
+                        },
+                        "esprima-fb": {
+                          "version": "15001.1.0-dev-harmony-fb",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
+                        },
+                        "recast": {
+                          "version": "0.10.24",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.24.tgz",
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.8.5",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.5.tgz"
+                            }
+                          }
+                        },
+                        "through": {
+                          "version": "2.3.8",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                        }
+                      }
+                    },
+                    "regexpu": {
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                      "dependencies": {
+                        "esprima": {
+                          "version": "2.6.0",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                        },
+                        "recast": {
+                          "version": "0.10.33",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.8.12",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                            },
+                            "esprima-fb": {
+                              "version": "15001.1001.0-dev-harmony-fb",
+                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                            },
+                            "source-map": {
+                              "version": "0.5.1",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.1.tgz"
+                            }
+                          }
+                        },
+                        "regenerate": {
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                        },
+                        "regjsgen": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                        },
+                        "regjsparser": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                          "dependencies": {
+                            "jsesc": {
+                              "version": "0.5.0",
+                              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "resolve": {
+                      "version": "1.1.6",
+                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+                    },
+                    "shebang-regex": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                    },
+                    "slash": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.4.4",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "source-map-support": {
+                      "version": "0.2.10",
+                      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.1.32",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    },
+                    "trim-right": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                    },
+                    "try-resolve": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                    }
+                  }
+                },
+                "esformatter-ignore": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/esformatter-ignore/-/esformatter-ignore-0.1.3.tgz"
+                },
+                "extend": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+                },
+                "falafel": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                    },
+                    "foreach": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    "object-keys": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz"
                     }
                   }
                 },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                "js-beautify": {
+                  "version": "1.5.10",
+                  "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
+                  "dependencies": {
+                    "config-chain": {
+                      "version": "1.1.9",
+                      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                      "dependencies": {
+                        "ini": {
+                          "version": "1.3.4",
+                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                        },
+                        "proto-list": {
+                          "version": "1.2.4",
+                          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "nopt": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.7",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
-            "debug": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+            "esformatter-literal-notation": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/esformatter-literal-notation/-/esformatter-literal-notation-1.0.1.tgz",
               "dependencies": {
-                "ms": {
-                  "version": "0.7.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
-                }
-              }
-            },
-            "doctrine": {
-              "version": "0.6.4",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "1.1.6",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                "rocambole": {
+                  "version": "0.3.6",
+                  "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.3.6.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    }
+                  }
                 },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                "rocambole-token": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
                 }
               }
             },
-            "escape-string-regexp": {
+            "esformatter-quotes": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/esformatter-quotes/-/esformatter-quotes-1.0.3.tgz"
             },
-            "escope": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-2.0.6.tgz",
+            "esformatter-semicolon-first": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/esformatter-semicolon-first/-/esformatter-semicolon-first-1.1.0.tgz",
               "dependencies": {
-                "es6-map": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+                "espree": {
+                  "version": "2.2.5",
+                  "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+                },
+                "rocambole": {
+                  "version": "0.7.0",
+                  "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
                   "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.6",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-                      "dependencies": {
-                        "es6-symbol": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "es6-iterator": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "dependencies": {
-                        "es6-symbol": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "es6-set": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
-                    },
-                    "event-emitter": {
-                      "version": "0.3.3",
-                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    "esprima": {
+                      "version": "2.6.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
                     }
                   }
                 },
-                "es6-weak-map": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.6",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz"
-                    },
-                    "es6-iterator": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                    }
-                  }
+                "rocambole-token": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
+                }
+              }
+            },
+            "esformatter-spaced-lined-comment": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/esformatter-spaced-lined-comment/-/esformatter-spaced-lined-comment-2.0.1.tgz"
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "stdin": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "standard-format": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/standard-format/-/standard-format-1.6.8.tgz",
+      "dependencies": {
+        "deglob": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.0.1.tgz",
+          "dependencies": {
+            "dezalgo": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
                 },
-                "esrecurse": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-1.2.0.tgz"
-                },
-                "util-extend": {
+                "wrappy": {
                   "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "find-root": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.1.tgz"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            },
+            "ignore": {
+              "version": "2.2.18",
+              "resolved": "https://registry.npmjs.org/ignore/-/ignore-2.2.18.tgz"
+            },
+            "path": {
+              "version": "0.11.14",
+              "resolved": "https://registry.npmjs.org/path/-/path-0.11.14.tgz"
+            },
+            "pkg-config": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.0.tgz",
+              "dependencies": {
+                "debug-log": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.0.tgz"
+                }
+              }
+            },
+            "run-parallel": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.4.tgz"
+            },
+            "uniq": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "esformatter": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.7.3.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            },
+            "disparity": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                },
+                "diff": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
                 }
               }
             },
@@ -1294,211 +3534,59 @@
               "version": "1.12.3",
               "resolved": "https://registry.npmjs.org/espree/-/espree-1.12.3.tgz"
             },
-            "estraverse": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
-            },
-            "estraverse-fb": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
-            },
-            "globals": {
-              "version": "6.4.1",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
-            },
-            "js-yaml": {
-              "version": "3.2.7",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
-                "argparse": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                "inflight": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
-                    "lodash": {
-                      "version": "3.7.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
-                    },
-                    "sprintf-js": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
-                "esprima": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
                     }
                   }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-            },
-            "optionator": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-              "dependencies": {
-                "deep-is": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
-                "fast-levenshtein": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
-                },
-                "levn": {
-                  "version": "0.2.5",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
-                },
-                "prelude-ls": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.1",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "user-home": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-            },
-            "xml-escape": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
-            }
-          }
-        },
-        "eslint-plugin-react": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.1.1.tgz"
-        },
-        "find-root": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.1.tgz"
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-        },
-        "glob": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                "once": {
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
-            },
-            "once": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
-        },
-        "run-parallel": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.0.tgz"
-        },
-        "uniq": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
-        }
-      }
-    },
-    "standard-format": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/standard-format/-/standard-format-1.3.6.tgz",
-      "dependencies": {
-        "esformatter": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.6.1.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             },
             "mout": {
               "version": "0.11.0",
@@ -1509,12 +3597,24 @@
               "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-1.1.1.tgz",
               "dependencies": {
                 "npm-path": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.0.1.tgz",
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.0.2.tgz",
                   "dependencies": {
                     "which": {
-                      "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                      "dependencies": {
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },
@@ -1523,8 +3623,8 @@
                   "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.1.tgz",
                   "dependencies": {
                     "protochain": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.2.tgz"
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.3.tgz"
                     }
                   }
                 },
@@ -1534,45 +3634,31 @@
                 }
               }
             },
-            "optimist": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                }
-              }
-            },
             "resolve": {
               "version": "1.1.6",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "rocambole": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.6.0.tgz",
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
               "dependencies": {
                 "esprima": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                  "version": "2.6.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
                 }
               }
             },
             "rocambole-indent": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.3.tgz",
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
               "dependencies": {
                 "debug": {
-                  "version": "2.1.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
-                      "version": "0.7.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                      "version": "0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 }
@@ -1583,18 +3669,18 @@
               "resolved": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.1.tgz",
               "dependencies": {
                 "debug": {
-                  "version": "2.1.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
-                      "version": "0.7.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                      "version": "0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "semver": {
-                  "version": "4.3.3",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+                  "version": "4.3.6",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 }
               }
             },
@@ -1611,12 +3697,12 @@
               "resolved": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
               "dependencies": {
                 "debug": {
-                  "version": "2.1.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
-                      "version": "0.7.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                      "version": "0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
@@ -1633,6 +3719,20 @@
             "strip-json-comments": {
               "version": "0.1.3",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            },
+            "user-home": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                }
+              }
             }
           }
         },
@@ -1646,9 +3746,615 @@
             }
           }
         },
+        "esformatter-jsx": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/esformatter-jsx/-/esformatter-jsx-2.3.5.tgz",
+          "dependencies": {
+            "babel-core": {
+              "version": "5.8.25",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.25.tgz",
+              "dependencies": {
+                "babel-plugin-constant-folding": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                },
+                "babel-plugin-dead-code-elimination": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                },
+                "babel-plugin-eval": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                },
+                "babel-plugin-inline-environment-variables": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                },
+                "babel-plugin-jscript": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                },
+                "babel-plugin-member-expression-literals": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                },
+                "babel-plugin-property-literals": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                },
+                "babel-plugin-proto-to-assign": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                },
+                "babel-plugin-react-constant-elements": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                },
+                "babel-plugin-react-display-name": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                },
+                "babel-plugin-remove-console": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                },
+                "babel-plugin-remove-debugger": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                },
+                "babel-plugin-runtime": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                },
+                "babel-plugin-undeclared-variables-check": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "dependencies": {
+                    "leven": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-undefined-to-void": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                },
+                "babylon": {
+                  "version": "5.8.23",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.23.tgz"
+                },
+                "bluebird": {
+                  "version": "2.10.2",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                },
+                "chalk": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "convert-source-map": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                },
+                "core-js": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.1.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                },
+                "home-or-tmp": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                    }
+                  }
+                },
+                "is-integer": {
+                  "version": "1.0.6",
+                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                },
+                "line-numbers": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                  "dependencies": {
+                    "left-pad": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "output-file-sync": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "regenerator": {
+                  "version": "0.8.35",
+                  "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.35.tgz",
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.3",
+                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "2.5.1",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+                        },
+                        "glob": {
+                          "version": "4.2.2",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.7.0",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.2",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "3.0.8",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                        },
+                        "install": {
+                          "version": "0.1.8",
+                          "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.5",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                        },
+                        "esprima-fb": {
+                          "version": "8001.1001.0-dev-harmony-fb",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                        },
+                        "yargs": {
+                          "version": "1.3.3",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1.0-dev-harmony-fb",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.24",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.24.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.5",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.5.tgz"
+                        }
+                      }
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.6.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                        },
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.5.1",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.1.tgz"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                },
+                "slash": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                },
+                "try-resolve": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                }
+              }
+            },
+            "esformatter-ignore": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/esformatter-ignore/-/esformatter-ignore-0.1.3.tgz"
+            },
+            "extend": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+            },
+            "falafel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                },
+                "foreach": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "object-keys": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz"
+                }
+              }
+            },
+            "js-beautify": {
+              "version": "1.5.10",
+              "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.9",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                  "dependencies": {
+                    "ini": {
+                      "version": "1.3.4",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "esformatter-literal-notation": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/esformatter-literal-notation/-/esformatter-literal-notation-1.0.0.tgz",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/esformatter-literal-notation/-/esformatter-literal-notation-1.0.1.tgz",
           "dependencies": {
             "rocambole": {
               "version": "0.3.6",
@@ -1667,70 +4373,40 @@
           }
         },
         "esformatter-quotes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/esformatter-quotes/-/esformatter-quotes-1.0.1.tgz"
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/esformatter-quotes/-/esformatter-quotes-1.0.3.tgz"
+        },
+        "esformatter-semicolon-first": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/esformatter-semicolon-first/-/esformatter-semicolon-first-1.1.0.tgz",
+          "dependencies": {
+            "espree": {
+              "version": "2.2.5",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+            },
+            "rocambole": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "2.6.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                }
+              }
+            },
+            "rocambole-token": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
+            }
+          }
         },
         "esformatter-spaced-lined-comment": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/esformatter-spaced-lined-comment/-/esformatter-spaced-lined-comment-2.0.1.tgz"
         },
-        "find-root": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.1.tgz"
-        },
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "once": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "minimatch": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
         "minimist": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "stdin": {
           "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
     "url": "https://github.com/pdehaan/grunt-standard/issues"
   },
   "dependencies": {
-    "chalk": "1.0.0",
-    "promise": "7.0.0",
-    "standard": "3.7.0",
-    "standard-format": "1.3.6",
+    "chalk": "1.1.1",
+    "promise": "7.0.4",
+    "standard": "5.3.1",
+    "standard-format": "1.6.8",
     "text-table": "0.2.0"
   },
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-nsp-shrinkwrap": "0.0.3",
-    "npm-shrinkwrap": "5.3.0"
+    "npm-shrinkwrap": "^5.4.0"
   },
   "engines": {
     "node": ">=0.10.0"
@@ -36,9 +36,6 @@
     }
   ],
   "main": "Gruntfile.js",
-  "peerDependencies": {
-    "grunt": "0.4.5"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/pdehaan/grunt-standard.git"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-nsp-shrinkwrap": "0.0.3",
-    "npm-shrinkwrap": "^5.4.0"
+    "npm-shrinkwrap": "5.4.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Updating the dependencies to fix an issue I had where linting would cause an error.  This solves #4 and #2.

I wasn't able to solve all the shrinkwrap validation errors, but they all appear to exist on `master` anyway.

```
tvrqvoise@lemon grunt-standard % npm run postshrinkwrap
> grunt-standard@1.0.2 postshrinkwrap /home/tvrqvoise/Code/grunt-standard
> grunt validate-shrinkwrap --force

Running "validate-shrinkwrap" task
/home/tvrqvoise/grunt-standard/npm-shrinkwrap.json
>> Name    Installed  Patched  Vulnerable Dependency
>> qs        0.6.6     >= 1.x  grunt-standard > npm-shrinkwrap > npm > request
>> qs        0.6.6     >= 1.x  grunt-standard > npm-shrinkwrap > npm > request
>> semver    2.3.0    >=4.3.2  grunt-standard > npm-shrinkwrap > npm
>> semver    2.2.1    >=4.3.2  grunt-standard > standard-format > esformatter
Warning: known vulnerable modules found Used --force, continuing.

Done, but with warnings.
```

Let me know if I'm doing something wrong here -- I don't normally shrinkwrap, so I could be missing something.

On top of that, I fixed a scope issue when denodifying the linter, and some minor whitespace stuff which `$ npm test` was angry about.
